### PR TITLE
Sky mods

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,103 +15,103 @@
 
 // Do not load directly.
 if ( ! defined( 'ABSPATH' ) ) {
-	die( '-1' );
+    die( '-1' );
 }
 
 // Do not load unless Tribe Common is fully loaded.
 if ( ! class_exists( 'Tribe__Extension' ) ) {
-	return;
+    return;
 }
 
 class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
-	private static $version = "1.2.0";
+    private static $version = "1.2.0";
 
-	/**
-	 * Setup the Extension's properties.
-	 *
-	 */
-	public function construct() {
-		$this->add_required_plugin( 'Tribe__Events__Main' );
-		$this->add_required_plugin( 'Tribe__Tickets__Main');
-	}
-
-	/**
-	 * Extension initialization and hooks.
-	 */
-	public function init() {
-		//add settings panel
-		add_action( 'tribe_settings_do_tabs', [ $this, 'add_settings_tabs' ] );
-
-		//hide the saved field in the frontend
-		add_filter( 'tribe_get_custom_fields', [ $this, 'hide_online_event_fields_from_details' ] );
-
-		//add Event Link in the Ticket Email
-		add_action( 'tribe_tickets_ticket_email_ticket_bottom', [ $this, 'render_online_link_in_email' ] );
-
-		//disable QR Code
-		add_filter( 'tribe_tickets_plus_qr_enabled', [ $this, 'disable_qr_code' ], 10, 2 );
-
-		//add support for TEC Pro
-		$this->add_support_tec_pro();
-
-		//add support for Events Control Extension
-		$this->add_support_events_control_extension();
+    /**
+     * Setup the Extension's properties.
+     *
+     */
+    public function construct() {
+        $this->add_required_plugin( 'Tribe__Events__Main' );
+        $this->add_required_plugin( 'Tribe__Tickets__Main');
     }
 
     /**
-	 * Add The Events Calendar PRO support
-	 */
-	public function add_support_tec_pro() {
-		if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
-			add_filter( 'tribe_ext_online_event_setting_options', [ $this, 'add_tec_pro_setting' ], 10 );
-		}
-	}
+     * Extension initialization and hooks.
+     */
+    public function init() {
+        //add settings panel
+        add_action( 'tribe_settings_do_tabs', [ $this, 'add_settings_tabs' ] );
 
-	/**
-	 * Filter Setting options
-	 *
-	 * @param $options
-	 *
-	 * @return mixed
-	 */
-	public function add_tec_pro_setting( $options ) {
+        //hide the saved field in the frontend
+        add_filter( 'tribe_get_custom_fields', [ $this, 'hide_online_event_fields_from_details' ] );
 
-		$fields = [];
+        //add Event Link in the Ticket Email
+        add_action( 'tribe_tickets_ticket_email_ticket_bottom', [ $this, 'render_online_link_in_email' ] );
 
-		//created additional fields
-		$custom_fields = tribe_get_option( 'custom-fields' );
+        //disable QR Code
+        add_filter( 'tribe_tickets_plus_qr_enabled', [ $this, 'disable_qr_code' ], 10, 2 );
 
-		if ( ! empty( $custom_fields ) ) {
-			$fields[0] = __( 'Select a Field', 'tribe-ext-online-events' );
-			foreach ( $custom_fields as $field ) {
-				$fields[ $field['name'] ] = $field['label'];
-			}
-		}
+        //add support for TEC Pro
+        $this->add_support_tec_pro();
 
-		$options['fields']['eventsOnlineField'] = [
-			'type'            => 'dropdown',
-			'label'           => __( 'Events Additional Field that contains Event link', 'tribe-ext-online-events' ),
-			'default'         => false,
-			'validation_type' => 'options',
-			'options'         => $fields,
-			'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
-			'can_be_empty'    => true,
-		];
+        //add support for Events Control Extension
+        $this->add_support_events_control_extension();
+    }
 
-		return $options;
-	}
+    /**
+     * Add The Events Calendar PRO support
+     */
+    public function add_support_tec_pro() {
+        if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
+            add_filter( 'tribe_ext_online_event_setting_options', [ $this, 'add_tec_pro_setting' ], 10 );
+        }
+    }
 
-	/**
-	 * Hide the selected additional field from Event Details
-	 *
-	 * @param $data array
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array
-	 */
-	public function hide_online_event_fields_from_details( $data ) {
+    /**
+     * Filter Setting options
+     *
+     * @param $options
+     *
+     * @return mixed
+     */
+    public function add_tec_pro_setting( $options ) {
+
+        $fields = [];
+
+        //created additional fields
+        $custom_fields = tribe_get_option( 'custom-fields' );
+
+        if ( ! empty( $custom_fields ) ) {
+            $fields[0] = __( 'Select a Field', 'tribe-ext-online-events' );
+            foreach ( $custom_fields as $field ) {
+                $fields[ $field['name'] ] = $field['label'];
+            }
+        }
+
+        $options['fields']['eventsOnlineField'] = [
+            'type'            => 'dropdown',
+            'label'           => __( 'Events Additional Field that contains Event link', 'tribe-ext-online-events' ),
+            'default'         => false,
+            'validation_type' => 'options',
+            'options'         => $fields,
+            'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
+            'can_be_empty'    => true,
+        ];
+
+        return $options;
+    }
+
+    /**
+     * Hide the selected additional field from Event Details
+     *
+     * @param $data array
+     *
+     * @since 1.0.0
+     *
+     * @return array
+     */
+    public function hide_online_event_fields_from_details( $data ) {
 
         $fields = $this->get_fields();
         $blacklist = [];
@@ -124,102 +124,102 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
         foreach( tribe_get_option( 'custom-fields' ) as $field ) {
 
-			if( in_array( $field['name'], $blacklist ) ) {
+            if( in_array( $field['name'], $blacklist ) ) {
 
                 if( isset( $data[ $field['label'] ] ) ) {
                     unset( $data[ $field['label'] ] );
                 }
-			}
-		}
+            }
+        }
 
-		return $data;
-	}
-
-	/**
-	 * Register the settings tab and fields
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function add_settings_tabs() {
-        $additional_email_fields = $this->get_fields();
-		require_once( dirname( __FILE__ ) . '/src/admin-views/tribe-options-virtual.php' );
-		new Tribe__Settings_Tab( 'online-events', __( 'Online Events', 'tribe-events-calendar-pro' ), $onlineTab );
+        return $data;
     }
-
-	/**
-	 * Disable showing QR Code for Events with selected category
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param $enabled bool
-	 * @param $ticket array
-	 *
-	 * @return bool
-	 */
-	public function disable_qr_code( $enabled, $ticket ) {
-
-		if ( ! isset( $ticket['event_id'] ) ) {
-			return $enabled;
-		}
-
-		$event = tribe_get_event( $ticket['event_id'] );
-
-		if ( ! $this->is_online_event( $event ) ) {
-			return $enabled;
-		}
-
-		return false;
-	}
 
     /**
-	 * Get selected category
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string
-	 */
-	public function get_online_category() {
-		return tribe_get_option( 'eventsOnlineCategory' );
+     * Register the settings tab and fields
+     *
+     * @since 1.0.0
+     *
+     * @return void
+     */
+    public function add_settings_tabs() {
+        $additional_email_fields = $this->get_fields();
+        require_once( dirname( __FILE__ ) . '/src/admin-views/tribe-options-virtual.php' );
+        new Tribe__Settings_Tab( 'online-events', __( 'Online Events', 'tribe-events-calendar-pro' ), $onlineTab );
     }
 
-	/**
-	 * Check if the event contains the Selected category
-	 *
-	 * @param $event WP_Post
-	 *
-	 * @return bool
-	 */
-	public function is_online_event( $event ) {
+    /**
+     * Disable showing QR Code for Events with selected category
+     *
+     * @since 1.0.0
+     *
+     * @param $enabled bool
+     * @param $ticket array
+     *
+     * @return bool
+     */
+    public function disable_qr_code( $enabled, $ticket ) {
 
-		$online_id = $this->get_online_category();
+        if ( ! isset( $ticket['event_id'] ) ) {
+            return $enabled;
+        }
 
-		//bail out if no online category id is set
-		if ( ! $online_id ) {
-			return false;
-		}
+        $event = tribe_get_event( $ticket['event_id'] );
 
-		//get event cats
-		$event_cats = wp_get_post_terms( $event->ID, Tribe__Events__Main::instance()->get_event_taxonomy() );
-		$cat_ids    = wp_list_pluck( $event_cats, 'term_id' );
+        if ( ! $this->is_online_event( $event ) ) {
+            return $enabled;
+        }
 
-		if ( empty( $cat_ids ) ) {
-			return false;
-		}
+        return false;
+    }
 
-		//check if cat exists
-		return in_array( $online_id, $cat_ids );
-	}
+    /**
+     * Get selected category
+     *
+     * @since 1.0.0
+     *
+     * @return string
+     */
+    public function get_online_category() {
+        return tribe_get_option( 'eventsOnlineCategory' );
+    }
 
-	/**
-	 * Get Fields
-	 *
-	 * @since 1.1.0
-	 *
-	 * @return array
-	 */
-	private function get_fields() {
+    /**
+     * Check if the event contains the Selected category
+     *
+     * @param $event WP_Post
+     *
+     * @return bool
+     */
+    public function is_online_event( $event ) {
+
+        $online_id = $this->get_online_category();
+
+        //bail out if no online category id is set
+        if ( ! $online_id ) {
+            return false;
+        }
+
+        //get event cats
+        $event_cats = wp_get_post_terms( $event->ID, Tribe__Events__Main::instance()->get_event_taxonomy() );
+        $cat_ids    = wp_list_pluck( $event_cats, 'term_id' );
+
+        if ( empty( $cat_ids ) ) {
+            return false;
+        }
+
+        //check if cat exists
+        return in_array( $online_id, $cat_ids );
+    }
+
+    /**
+     * Get Fields
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    private function get_fields() {
 
         $fields = [
             'id' => [
@@ -244,30 +244,30 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
         return $fields;
     }
 
-	/**
-	 * Render Event Link within Ticket Email
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param $ticket array
-	 */
-	public function render_online_link_in_email( $ticket ) {
+    /**
+     * Render Event Link within Ticket Email
+     *
+     * @since 1.0.0
+     *
+     * @param $ticket array
+     */
+    public function render_online_link_in_email( $ticket ) {
 
-		$event_id = isset( $ticket['event_id'] ) ? $ticket['event_id'] : 0;
+        $event_id = isset( $ticket['event_id'] ) ? $ticket['event_id'] : 0;
 
-		$event = tribe_get_event( $event_id );
+        $event = tribe_get_event( $event_id );
 
-		if ( ! empty( $event ) && ! tribe_is_event( $event ) ) {
-			return;
-		}
+        if ( ! empty( $event ) && ! tribe_is_event( $event ) ) {
+            return;
+        }
 
-		if ( ! $this->is_online_event( $event ) ) {
-			return;
-		}
+        if ( ! $this->is_online_event( $event ) ) {
+            return;
+        }
 
         $heading = tribe_get_option( 'eventsOnlineHeading' );
         $fields = $this->get_fields();
-		?>
+        ?>
         <div style="background:#f7f7f7;padding:25px;margin:15px 0;">
             <h3 style="color:#0a0a0e;margin:0 0 25px 0!important;font-family:'Helvetica Neue',Helvetica,sans-serif;text-decoration: underline;font-weight:700;font-size:28px;text-align:left;">
                 <span style="color:#0a0a0e!important"><?php _e( $heading, 'tribe-ext-online-events' ); ?></span>
@@ -291,111 +291,111 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
                 </tbody>
             </table>
         </div>
-		<?php
+        <?php
     }
 
    /**
-	 * Add Support for Events Control
-	 *
-	 * @since 1.1.0
-	 */
-	public function add_support_events_control_extension() {
-		if ( class_exists( 'Tribe\Extensions\EventsControl\Event_Meta' ) ) {
-			//Provide an option to select
-			add_filter( 'tribe_ext_online_event_is_online', [ $this, 'events_control_is_online' ], 10, 2 );
-			add_filter( 'tribe_ext_online_event_online_field', [ $this, 'events_control_online_field' ] );
-			add_filter( 'tribe_ext_online_event_setting_options', [ $this, 'events_control_options' ], 20 );
-			add_filter( 'tribe_template_pre_html', [ $this, 'remove_location_marker_from_frontend' ], 20, 4 );
-		}
-	}
-
-	/**
-	 * Check if Event is online from Event Controls
-	 *
-	 * @param $is_online
-	 * @param $event
+     * Add Support for Events Control
      *
      * @since 1.1.0
-	 *
-	 * @return boolean
-	 */
-	public function events_control_is_online( $is_online, $event ) {
-		$event_meta        = tribe( 'Tribe\Extensions\EventsControl\Event_Meta' );
-		$event_meta_online = $event_meta->is_online( $event );
+     */
+    public function add_support_events_control_extension() {
+        if ( class_exists( 'Tribe\Extensions\EventsControl\Event_Meta' ) ) {
+            //Provide an option to select
+            add_filter( 'tribe_ext_online_event_is_online', [ $this, 'events_control_is_online' ], 10, 2 );
+            add_filter( 'tribe_ext_online_event_online_field', [ $this, 'events_control_online_field' ] );
+            add_filter( 'tribe_ext_online_event_setting_options', [ $this, 'events_control_options' ], 20 );
+            add_filter( 'tribe_template_pre_html', [ $this, 'remove_location_marker_from_frontend' ], 20, 4 );
+        }
+    }
 
-		return $event_meta_online ? $event_meta_online : $is_online;
-	}
-
-	/**
-	 * Filter Event Link URL for Events Control
-	 *
-	 * @param $field
+    /**
+     * Check if Event is online from Event Controls
+     *
+     * @param $is_online
+     * @param $event
      *
      * @since 1.1.0
-	 *
-	 * @return mixed
-	 */
-	public function events_control_online_field( $field ) {
-		$event_meta = tribe( 'Tribe\Extensions\EventsControl\Event_Meta' );
+     *
+     * @return boolean
+     */
+    public function events_control_is_online( $is_online, $event ) {
+        $event_meta        = tribe( 'Tribe\Extensions\EventsControl\Event_Meta' );
+        $event_meta_online = $event_meta->is_online( $event );
 
-		return $event_meta::$key_online_url;
-	}
+        return $event_meta_online ? $event_meta_online : $is_online;
+    }
 
-	/**
-	 * Add options for Events Control extension
-	 *
-	 * @param $options
+    /**
+     * Filter Event Link URL for Events Control
+     *
+     * @param $field
      *
      * @since 1.1.0
-	 *
-	 * @return array
-	 */
-	public function events_control_options( $options ) {
-		$remove_fields = [
-			'eventsOnlineCategoryHelperTitle',
-			'eventsOnlineCategory',
-			'eventsOnlineFieldHelperTitle',
-			'eventsOnlineField',
-		];
+     *
+     * @return mixed
+     */
+    public function events_control_online_field( $field ) {
+        $event_meta = tribe( 'Tribe\Extensions\EventsControl\Event_Meta' );
 
-		foreach ( $remove_fields as $field ) {
-			unset( $options['fields'][ $field ] );
-		}
+        return $event_meta::$key_online_url;
+    }
 
-		$options['fields']['info-box-description']['html'] = __( 'You have <a target="_blank" href="https://theeventscalendar.com/extensions/event-statuses/">The Events Control</a> extension installed with options for selecting Online Events and an Event URL. <p>Event URLs for marked online events will be sent in ticket email.</p>', 'tribe-ext-online-events' );
+    /**
+     * Add options for Events Control extension
+     *
+     * @param $options
+     *
+     * @since 1.1.0
+     *
+     * @return array
+     */
+    public function events_control_options( $options ) {
+        $remove_fields = [
+            'eventsOnlineCategoryHelperTitle',
+            'eventsOnlineCategory',
+            'eventsOnlineFieldHelperTitle',
+            'eventsOnlineField',
+        ];
 
-		$options['fields']['eventsControlHideLink'] = [
-			'type'            => 'checkbox_bool',
-			'label'           => esc_html__( 'Hide Event\'s Online URL in the Event Page', 'tribe-ext-online-events' ),
-			'default'         => false,
-			'validation_type' => 'boolean',
-		];
+        foreach ( $remove_fields as $field ) {
+            unset( $options['fields'][ $field ] );
+        }
 
-		return $options;
-	}
+        $options['fields']['info-box-description']['html'] = __( 'You have <a target="_blank" href="https://theeventscalendar.com/extensions/event-statuses/">The Events Control</a> extension installed with options for selecting Online Events and an Event URL. <p>Event URLs for marked online events will be sent in ticket email.</p>', 'tribe-ext-online-events' );
 
-	/**
+        $options['fields']['eventsControlHideLink'] = [
+            'type'            => 'checkbox_bool',
+            'label'           => esc_html__( 'Hide Event\'s Online URL in the Event Page', 'tribe-ext-online-events' ),
+            'default'         => false,
+            'validation_type' => 'boolean',
+        ];
+
+        return $options;
+    }
+
+    /**
      * Filter HTML template to hide the online URL
      *
-	 * @param $pre_html
-	 * @param $file
-	 * @param $name
-	 * @param $template_class
+     * @param $pre_html
+     * @param $file
+     * @param $name
+     * @param $template_class
      *
      * @since 1.1.0
-	 *
-	 * @return string
-	 */
-	public function remove_location_marker_from_frontend( $pre_html, $file, $name, $template_class ) {
+     *
+     * @return string
+     */
+    public function remove_location_marker_from_frontend( $pre_html, $file, $name, $template_class ) {
 
-		if ( 'single/online-marker' != implode( '/', $name ) ) {
-			return $pre_html;
-		}
+        if ( 'single/online-marker' != implode( '/', $name ) ) {
+            return $pre_html;
+        }
 
-		if ( ! tribe_is_truthy( tribe_get_option( 'eventsControlHideLink' ) ) ) {
-			return $pre_html;
-		}
+        if ( ! tribe_is_truthy( tribe_get_option( 'eventsControlHideLink' ) ) ) {
+            return $pre_html;
+        }
 
-		return '';
-	}
+        return '';
+    }
 }

--- a/index.php
+++ b/index.php
@@ -125,6 +125,17 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 		return false;
 	}
 
+    /**
+	 * Get selected category
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string
+	 */
+	public function get_online_category() {
+		return tribe_get_option( 'eventsOnlineCategory' );
+    }
+
 	/**
 	 * Check if the event contains the Selected category
 	 *
@@ -183,14 +194,6 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
         $fields = apply_filters( 'tribe/events-online/email-fields', $fields );
 
         return $fields;
-	 * Get selected Field
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return mixed
-	 */
-	public function get_event_online_field() {
-		return tribe_get_option( 'eventsOnlineField' );
     }
 
 	/**

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 		add_action( 'tribe_settings_do_tabs', array( $this, 'add_settings_tabs' ) );
 
 		//hide the saved field in the frontend
-		add_filter( 'tribe_get_custom_fields', array( $this, 'hide_online_link_field_from_details' ) );
+		add_filter( 'tribe_get_custom_fields', array( $this, 'hide_online_event_fields_from_details' ) );
 
 		//add Event Link in the Ticket Email
 		add_action( 'tribe_tickets_ticket_email_ticket_bottom', array( $this, 'render_online_link_in_email' ) );
@@ -63,7 +63,7 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	 *
 	 * @return array
 	 */
-	public function hide_online_link_field_from_details( $data ) {
+	public function hide_online_event_fields_from_details( $data ) {
 
 		$saved_field = $this->get_event_online_field();
 		if ( empty( $saved_field ) ) {

--- a/index.php
+++ b/index.php
@@ -230,7 +230,7 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
                         <?php foreach( $fields as $field => $args):
                             $value = get_post_meta( $event_id, tribe_get_option( $args['option'] ), true );
                             if( ! $value ) continue; ?>
-                            <td valign="top" align="left" style="padding:0;margin:0!important;">
+                            <td valign="top" align="left" width="120">
                                 <h6 style="color:#909090!important;margin:0 0 10px 0;font-family:'Helvetica Neue',Helvetica,sans-serif;text-transform:uppercase;font-size:13px;font-weight:700!important;">
                                     <?php echo esc_html( $args['label'] ) ?>
                                 </h6>

--- a/index.php
+++ b/index.php
@@ -101,6 +101,31 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	}
 
 	/**
+	 * Disable showing QR Code for Events with selected category
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $enabled bool
+	 * @param $ticket array
+	 *
+	 * @return bool
+	 */
+	public function disable_qr_code( $enabled, $ticket ) {
+
+		if ( ! isset( $ticket['event_id'] ) ) {
+			return $enabled;
+		}
+
+		$event = tribe_get_event( $ticket['event_id'] );
+
+		if ( ! $this->is_online_event( $event ) ) {
+			return $enabled;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Check if the event contains the Selected category
 	 *
 	 * @param $event WP_Post
@@ -203,29 +228,5 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
             </tr>
         </table>
 		<?php
-	}
-
-	/**
-	 * Disable showing QR Code for Events with selected category
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param $enabled bool
-	 * @param $ticket array
-	 *
-	 * @return bool
-	 */
-	public function disable_qr_code( $enabled, $ticket ) {
-		if ( ! isset( $ticket['event_id'] ) ) {
-			return $enabled;
-		}
-
-		$event = tribe_get_event( $ticket['event_id'] );
-
-		if ( ! $this->is_online_event( $event ) ) {
-			return $enabled;
-		}
-
-		return false;
 	}
 }

--- a/src/admin-views/tribe-options-virtual.php
+++ b/src/admin-views/tribe-options-virtual.php
@@ -5,64 +5,64 @@ $fields     = [];
 
 if ( 'online-events' === tribe_get_request_var( 'tab' ) ) {
 
-	$taxonomy       = Tribe__Events__Main::instance()->get_event_taxonomy();
-	$selected_terms = [];
-	$taxonomy_obj   = get_taxonomy( $taxonomy );
+    $taxonomy       = Tribe__Events__Main::instance()->get_event_taxonomy();
+    $selected_terms = [];
+    $taxonomy_obj   = get_taxonomy( $taxonomy );
 
-	$terms = get_terms( $taxonomy, ['hide_empty' => false] );
+    $terms = get_terms( $taxonomy, ['hide_empty' => false] );
 
-	if ( ! empty( $terms ) ) {
-		$event_cats[0] = __( 'Select a category', 'tribe-ext-online-events' );
-		foreach ( $terms as $term ) {
-			$event_cats[ $term->term_id ] = $term->name;
-		}
-	}
+    if ( ! empty( $terms ) ) {
+        $event_cats[0] = __( 'Select a category', 'tribe-ext-online-events' );
+        foreach ( $terms as $term ) {
+            $event_cats[ $term->term_id ] = $term->name;
+        }
+    }
 
-	$custom_fields = tribe_get_option( 'custom-fields' );
+    $custom_fields = tribe_get_option( 'custom-fields' );
 
-	if ( ! empty( $custom_fields ) ) {
-		$fields[0] = __( 'Select a Field', 'tribe-ext-online-events' );
-		foreach ( $custom_fields as $field ) {
-			$fields[ $field['name'] ] = $field['label'];
-		}
-	}
+    if ( ! empty( $custom_fields ) ) {
+        $fields[0] = __( 'Select a Field', 'tribe-ext-online-events' );
+        foreach ( $custom_fields as $field ) {
+            $fields[ $field['name'] ] = $field['label'];
+        }
+    }
 }
 
 $onlineTab = [
-	'priority' => 30,
-	'fields'   => [
-		'info-start' => [
-			'type' => 'html',
-			'html' => '<div id="modern-tribe-info">',
+    'priority' => 30,
+    'fields'   => [
+        'info-start' => [
+            'type' => 'html',
+            'html' => '<div id="modern-tribe-info">',
         ],
-		'info-box-title' => [
-			'type' => 'html',
-			'html' => '<h2>' . __( 'Online Events', 'tribe-ext-online-events' ) . '</h2>',
+        'info-box-title' => [
+            'type' => 'html',
+            'html' => '<h2>' . __( 'Online Events', 'tribe-ext-online-events' ) . '</h2>',
         ],
-		'info-box-description' => [
-			'type' => 'html',
-			'html' => '<p>' . __( '<p>Choose the category and fields for events that are Online or Virtual. </p>', 'tribe-ext-online-events' ) . '</p>',
+        'info-box-description' => [
+            'type' => 'html',
+            'html' => '<p>' . __( '<p>Choose the category and fields for events that are Online or Virtual. </p>', 'tribe-ext-online-events' ) . '</p>',
         ],
-		'info-end' => [
-			'type' => 'html',
-			'html' => '</div>',
+        'info-end' => [
+            'type' => 'html',
+            'html' => '</div>',
         ],
-		'tribe-form-content-start' => [
-			'type' => 'html',
-			'html' => '<div class="tribe-settings-form-wrap">',
+        'tribe-form-content-start' => [
+            'type' => 'html',
+            'html' => '<div class="tribe-settings-form-wrap">',
         ],
-		'eventsOnlineCategoryHelperTitle' => [
-			'type' => 'html',
-			'html' => '<h3>' . __( 'Online Event Category', 'tribe-ext-online-events' ) . '</h3>',
+        'eventsOnlineCategoryHelperTitle' => [
+            'type' => 'html',
+            'html' => '<h3>' . __( 'Online Event Category', 'tribe-ext-online-events' ) . '</h3>',
         ],
-		'eventsOnlineCategory' => [
-			'type'            => 'dropdown',
-			'label'           => __( 'Category', 'tribe-ext-online-events' ),
-			'default'         => false,
-			'validation_type' => 'options',
-			'options'         => $event_cats,
-			'if_empty'        => __( 'No categories yet. Create a category under Events > Categories for your online events', 'tribe-ext-online-events' ),
-			'can_be_empty'    => true,
+        'eventsOnlineCategory' => [
+            'type'            => 'dropdown',
+            'label'           => __( 'Category', 'tribe-ext-online-events' ),
+            'default'         => false,
+            'validation_type' => 'options',
+            'options'         => $event_cats,
+            'if_empty'        => __( 'No categories yet. Create a category under Events > Categories for your online events', 'tribe-ext-online-events' ),
+            'can_be_empty'    => true,
         ],
         'eventsOnlineFieldHelperEmail' => [
             'type' => 'html',

--- a/src/admin-views/tribe-options-virtual.php
+++ b/src/admin-views/tribe-options-virtual.php
@@ -3,18 +3,13 @@
 $event_cats = [];
 $fields     = [];
 
-
 if ( 'online-events' === tribe_get_request_var( 'tab' ) ) {
+
 	$taxonomy       = Tribe__Events__Main::instance()->get_event_taxonomy();
 	$selected_terms = [];
 	$taxonomy_obj   = get_taxonomy( $taxonomy );
 
-	$terms = get_terms(
-		$taxonomy,
-		[
-			'hide_empty' => false,
-		]
-	);
+	$terms = get_terms( $taxonomy, ['hide_empty' => false] );
 
 	if ( ! empty( $terms ) ) {
 		$event_cats[0] = __( 'Select a category', 'tribe-ext-online-events' );
@@ -31,37 +26,36 @@ if ( 'online-events' === tribe_get_request_var( 'tab' ) ) {
 			$fields[ $field['name'] ] = $field['label'];
 		}
 	}
-
 }
 
-$onlineTab = array(
+$onlineTab = [
 	'priority' => 30,
-	'fields'   => array(
-		'info-start'                      => array(
+	'fields'   => [
+		'info-start' => [
 			'type' => 'html',
 			'html' => '<div id="modern-tribe-info">',
-		),
-		'info-box-title'                  => array(
+        ],
+		'info-box-title' => [
 			'type' => 'html',
 			'html' => '<h2>' . __( 'Online Events', 'tribe-ext-online-events' ) . '</h2>',
-		),
-		'info-box-description'            => array(
+        ],
+		'info-box-description' => [
 			'type' => 'html',
 			'html' => '<p>' . __( '<p>Choose the category and fields for events that are Online or Virtual. </p>', 'tribe-ext-online-events' ) . '</p>',
-		),
-		'info-end'                        => array(
+        ],
+		'info-end' => [
 			'type' => 'html',
 			'html' => '</div>',
-		),
-		'tribe-form-content-start'        => array(
+        ],
+		'tribe-form-content-start' => [
 			'type' => 'html',
 			'html' => '<div class="tribe-settings-form-wrap">',
-		),
-		'eventsOnlineCategoryHelperTitle' => array(
+        ],
+		'eventsOnlineCategoryHelperTitle' => [
 			'type' => 'html',
 			'html' => '<h3>' . __( 'Online Event Category', 'tribe-ext-online-events' ) . '</h3>',
-		),
-		'eventsOnlineCategory'            => array(
+        ],
+		'eventsOnlineCategory' => [
 			'type'            => 'dropdown',
 			'label'           => __( 'Category', 'tribe-ext-online-events' ),
 			'default'         => false,
@@ -69,44 +63,56 @@ $onlineTab = array(
 			'options'         => $event_cats,
 			'if_empty'        => __( 'No categories yet. Create a category under Events > Categories for your online events', 'tribe-ext-online-events' ),
 			'can_be_empty'    => true,
-		),
-		'eventsOnlineFieldHelperTitle'    => array(
-			'type' => 'html',
-			'html' => '<h3>' . __( 'Online Event Field', 'tribe-ext-online-events' ) . '</h3>',
-		),
-	)
-);
-if ( class_exists( 'Tribe__Events__Pro__Mains' ) ) {
-	$onlineTab['fields']['eventsOnlineField'] = array(
-		'type'            => 'dropdown',
-		'label'           => __( 'Events Additional Field that contains Event link', 'tribe-ext-online-events' ),
-		'default'         => false,
-		'validation_type' => 'options',
-		'options'         => $fields,
-		'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
-		'can_be_empty'    => true,
-	);
-} else {
-	$onlineTab['fields']['eventsOnlineField'] = array(
-		'type'            => 'text',
-		'label'           => __( 'Custom field that contains Event link', 'tribe-ext-online-events' ),
-		'default'         => '',
-		'tooltip'         => __( 'To know more about Custom fields visit the WordPress <a target="_blank" href="https://wordpress.org/support/article/custom-fields/">Custom Fields Wiki</a>', 'tribe-ext-online-events' ),
-		'can_be_empty'    => true,
-	);
+        ],
+        'eventsOnlineFieldHelperEmail' => [
+            'type' => 'html',
+            'html' => '<h3>' . __( 'Email options', 'tribe-ext-online-events' ) . '</h3>',
+        ],
+        'eventsOnlineHeading' => [
+            'type'            => 'text',
+            'label'           => __( 'Email Section Title' ),
+            'tooltip'         => '',
+            'default'         => 'Online Event Details',
+            'validation_type' => 'html',
+            'size'            => 'medium',
+            'can_be_empty'    => false,
+        ],
+        'eventsOnlineFieldHelperTitle' => [
+            'type' => 'html',
+            'html' => '<h3>' . __( 'Online Event Fields', 'tribe-ext-online-events' ) . '</h3>',
+        ]
+    ]
+];
+
+foreach( $additional_email_fields as $additional_email_field => $args ) {
+
+    $field_id = $args['option'];
+    $field_label = sprintf( __( 'Field for %s', 'tribe-ext-online-events' ), $args['label'] );
+
+    if ( class_exists( 'Tribe__Events__Pro__Main' ) ) {
+        $onlineTab['fields'][$field_id] = [
+            'type'            => 'dropdown',
+            'label'           => $field_label,
+            'default'         => false,
+            'validation_type' => 'options',
+            'options'         => $fields,
+            'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
+            'can_be_empty'    => true,
+        ];
+    }
+    else {
+        $onlineTab['fields'][$field_id] = [
+            'type'            => 'text',
+            'label'           => $field_label,
+            'default'         => '',
+            'can_be_empty'    => true,
+        ];
+    }
 }
 
-$onlineTab['fields']['eventsOnlineFieldHelperEmail'] = array(
-	'type' => 'html',
-	'html' => '<h3>' . __( 'Email options', 'tribe-ext-online-events' ) . '</h3>',
-);
-
-$onlineTab['fields']['eventsOnlineHeading'] = array(
-	'type'            => 'text',
-	'label'           => __( 'Email Heading for link' ),
-	'tooltip'         => '',
-	'default'         => 'Event Link',
-	'validation_type' => 'html',
-	'size'            => 'medium',
-	'can_be_empty'    => false,
-);
+if ( ! class_exists( 'Tribe__Events__Pro__Main' ) ) {
+    $onlineTab['fields']['eventsOnlineFieldHelperNotes'] = [
+        'type' => 'html',
+        'html' => '<p>' .  __( 'To learn more about custom fields visit the WordPress <a target="_blank" href="https://wordpress.org/support/article/custom-fields/">Custom Fields Wiki</a>', 'tribe-ext-online-events' ) . '</p>',
+    ];
+}


### PR DESCRIPTION
I modified this extension for a customer, and was encouraged to submit the changes here. 

While the original extension supports the webinar URL, customers are also wanting to display other information here, including the "meeting ID" and "password" fields that Zoom uses. 

I added these two fields to behave just as the URL field, but also added a filter that can be used to either: 
a) remove some of the existing fields
b) add different or modified fields

I also made some changes to the admin UI. I moved the custom field for the webinar section "title" to be above the other fields, to match how it actually appears in the email. 

Finally, I modified the markup that is output in the email to better match the original ticket content. The information is displayed in three sections horizontally, rather than vertically and centered. 