### PR TITLE
Add 2 more (optional) fields that can also be included for alternative streaming/online event locations.

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://theeventscalendar.com/extensions/add-a-private-event-link-to-ticket-emails/
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-online-event
  * Description:     An extension that allows you to send event links in ticket email to registrants only
- * Version:         1.1.1
+ * Version:         1.2
  * Extension Class: Tribe__Extension__Virtual__Event__Ticket
  * Author:          Modern Tribe, Inc.
  * Author URI:      http://m.tri.be/1971
@@ -25,7 +25,7 @@ if ( ! class_exists( 'Tribe__Extension' ) ) {
 
 class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
-	private static $version = '1.1.1';
+	private static $version = '1.2';
 
 	/**
 	 * Setup the Extension's properties.
@@ -90,7 +90,25 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
 		$options['fields']['eventsOnlineField'] = [
 			'type'            => 'dropdown',
-			'label'           => __( 'Events Additional Field that contains Event link', 'tribe-ext-online-events' ),
+			'label'           => __( '<strong>Event Link #1</strong> Additional Field', 'tribe-ext-online-events' ),
+			'default'         => false,
+			'validation_type' => 'options',
+			'options'         => $fields,
+			'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
+			'can_be_empty'    => true,
+		];
+		$options['fields']['eventsOnlineField2'] = [
+			'type'            => 'dropdown',
+			'label'           => __( '<strong>Event Link #2</strong> Additional Field', 'tribe-ext-online-events' ),
+			'default'         => false,
+			'validation_type' => 'options',
+			'options'         => $fields,
+			'if_empty'        => __( 'No Fields are found. You need to create an additional field. For help visit <a target="_blank" href="https://theeventscalendar.com/knowledgebase/k/pro-additional-fields/">here</a>', 'tribe-ext-online-events' ),
+			'can_be_empty'    => true,
+		];
+		$options['fields']['eventsOnlineField3'] = [
+			'type'            => 'dropdown',
+			'label'           => __( '<strong>Event Link #3</strong> Additional Field', 'tribe-ext-online-events' ),
 			'default'         => false,
 			'validation_type' => 'options',
 			'options'         => $fields,
@@ -211,6 +229,49 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	}
 
 	/**
+	 * Get email template output for an individual event link with header
+	 *
+	 * @since 1.2
+	 *
+	 * @return string
+	 */
+	public function get_email_link_template($online_link = '',$heading = '') {
+		$output = '
+        <table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff"
+	           style="margin:15px auto 0; padding:0;">
+	        <tr>
+	            <td align="center" valign="top" class="wrapper" width="620">
+	                <table class="inner-wrapper" border="0" cellpadding="0" cellspacing="0" width="620"
+	                       bgcolor="#f7f7f7" style="margin:0 auto !important; width:620px; padding:0;">
+	                    <tr>
+	                        <td valign="center" class="ticket-content" align="center" border="0" cellpadding="20"
+	                            cellspacing="0" style="padding:20px; background:#f7f7f7;">';
+	                            if(!empty($heading)){
+		                            $output.= '<h3 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: \'Helvetica Neue\', Helvetica, sans-serif; font-style:normal; text-decoration: underline; font-weight:700; font-size:28px; letter-spacing:normal; text-align:center;line-height: 100%;">
+	                                <span style="color:#0a0a0e !important">';
+	                                $output.= _e( $heading, 'tribe-ext-online-events' );
+	                                $output.= '</span>
+	                            </h3>';
+	                            }
+	                            $output.= '
+	                            <p>
+	                                <a href="';
+	                                $output.= esc_attr_e( $online_link );
+	                                $output.= '">';
+										$output.= $online_link;
+	                                $output.= '</a>
+	                            </p>
+	                        </td>
+	                    </tr>
+	                </table>
+	            </td>
+	        </tr>
+	    </table>
+	    ';
+	    return $output;
+	}
+
+	/**
 	 * Render Event Link within Ticket Email
 	 *
 	 * @param $ticket array
@@ -234,37 +295,22 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 		}
 
 		$online_link = get_post_meta( $event_id, $this->get_event_online_field(), true );
-
-		if ( empty( $online_link ) ) {
-			return;
+		if ( !empty( $online_link ) ) {
+			$heading = tribe_get_option( 'eventsOnlineHeading' );
+			echo $this->get_email_link_template($online_link,$heading);
 		}
 
-		$heading = tribe_get_option( 'eventsOnlineHeading' );
-		?>
-        <table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff"
-               style="margin:15px auto 0; padding:0;">
-            <tr>
-                <td align="center" valign="top" class="wrapper" width="620">
-                    <table class="inner-wrapper" border="0" cellpadding="0" cellspacing="0" width="620"
-                           bgcolor="#f7f7f7" style="margin:0 auto !important; width:620px; padding:0;">
-                        <tr>
-                            <td valign="center" class="ticket-content" align="center" border="0" cellpadding="20"
-                                cellspacing="0" style="padding:20px; background:#f7f7f7;">
-                                <h3 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: 'Helvetica Neue', Helvetica, sans-serif; font-style:normal; text-decoration: underline; font-weight:700; font-size:28px; letter-spacing:normal; text-align:center;line-height: 100%;">
-                                    <span style="color:#0a0a0e !important"><?php _e( $heading, 'tribe-ext-online-events' ); ?></span>
-                                </h3>
-                                <p>
-                                    <a href="<?php esc_attr_e( $online_link ) ?>">
-										<?php echo $online_link ?>
-                                    </a>
-                                </p>
-                            </td>
-                        </tr>
-                    </table>
-                </td>
-            </tr>
-        </table>
-		<?php
+		$online_link2 = tribe_get_option( 'eventsOnlineField2' );
+		if ( !empty( $online_link2 ) ) {
+			$heading2 = tribe_get_option( 'eventsOnlineHeading2' );
+			echo $this->get_email_link_template($online_link2,$heading2);
+		}
+
+		$online_link3 = tribe_get_option( 'eventsOnlineField3' );
+		if ( !empty( $online_link3 ) ) {
+			$heading3 = tribe_get_option( 'eventsOnlineHeading3' );
+			echo $this->get_email_link_template($online_link3,$heading3);
+		}
 	}
 
 	/**
@@ -353,6 +399,8 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 			'eventsOnlineCategory',
 			'eventsOnlineFieldHelperTitle',
 			'eventsOnlineField',
+			'eventsOnlineField2',
+			'eventsOnlineField3',
 		];
 
 		foreach ( $remove_fields as $field ) {

--- a/index.php
+++ b/index.php
@@ -44,6 +44,8 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
 		//hide the saved field in the frontend
 		add_filter( 'tribe_get_custom_fields', [ $this, 'hide_online_link_field_from_details' ] );
+		add_filter( 'tribe_get_custom_fields', [ $this, 'hide_online_link_field_from_details2' ] );
+		add_filter( 'tribe_get_custom_fields', [ $this, 'hide_online_link_field_from_details3' ] );
 
 		//add Event Link in the Ticket Email
 		add_action( 'tribe_tickets_ticket_email_ticket_bottom', [ $this, 'render_online_link_in_email' ] );
@@ -152,6 +154,54 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 
 		return $data;
 	}
+	public function hide_online_link_field_from_details2( $data ) {
+
+		$saved_field = $this->get_event_online_field2();
+		if ( empty( $saved_field ) ) {
+			return $data;
+		}
+
+		$custom_fields = tribe_get_option( 'custom-fields' );
+
+		$selected_field = '';
+
+		foreach ( $custom_fields as $field ) {
+			if ( $field['name'] == $saved_field ) {
+				$selected_field = $field['label'];
+				break;
+			}
+		}
+
+		if ( isset( $data[ $selected_field ] ) ) {
+			unset( $data[ $selected_field ] );
+		}
+
+		return $data;
+	}
+	public function hide_online_link_field_from_details3( $data ) {
+
+		$saved_field = $this->get_event_online_field3();
+		if ( empty( $saved_field ) ) {
+			return $data;
+		}
+
+		$custom_fields = tribe_get_option( 'custom-fields' );
+
+		$selected_field = '';
+
+		foreach ( $custom_fields as $field ) {
+			if ( $field['name'] == $saved_field ) {
+				$selected_field = $field['label'];
+				break;
+			}
+		}
+
+		if ( isset( $data[ $selected_field ] ) ) {
+			unset( $data[ $selected_field ] );
+		}
+
+		return $data;
+	}
 
 	/**
 	 * Register the settings tab and fields
@@ -227,6 +277,12 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	public function get_event_online_field() {
 		return apply_filters( 'tribe_ext_online_event_online_field', tribe_get_option( 'eventsOnlineField' ) );
 	}
+	public function get_event_online_field2() {
+		return apply_filters( 'tribe_ext_online_event_online_field', tribe_get_option( 'eventsOnlineField2' ) );
+	}
+	public function get_event_online_field3() {
+		return apply_filters( 'tribe_ext_online_event_online_field', tribe_get_option( 'eventsOnlineField3' ) );
+	}
 
 	/**
 	 * Get email template output for an individual event link with header
@@ -236,9 +292,8 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	 * @return string
 	 */
 	public function get_email_link_template($online_link = '',$heading = '') {
-		$output = '
-        <table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff"
-	           style="margin:15px auto 0; padding:0;">
+		$output = '<table class="content" align="center" width="620" cellspacing="0" cellpadding="0" border="0" bgcolor="#ffffff"
+	           style="margin:15px auto 15px; padding:0;">
 	        <tr>
 	            <td align="center" valign="top" class="wrapper" width="620">
 	                <table class="inner-wrapper" border="0" cellpadding="0" cellspacing="0" width="620"
@@ -249,14 +304,14 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 	                            if(!empty($heading)){
 		                            $output.= '<h3 style="color:#0a0a0e; margin:0 0 10px 0 !important; font-family: \'Helvetica Neue\', Helvetica, sans-serif; font-style:normal; text-decoration: underline; font-weight:700; font-size:28px; letter-spacing:normal; text-align:center;line-height: 100%;">
 	                                <span style="color:#0a0a0e !important">';
-	                                $output.= _e( $heading, 'tribe-ext-online-events' );
+	                                $output.= __( $heading, 'tribe-ext-online-events' );
 	                                $output.= '</span>
 	                            </h3>';
 	                            }
 	                            $output.= '
 	                            <p>
 	                                <a href="';
-	                                $output.= esc_attr_e( $online_link );
+	                                $output.= esc_attr( $online_link );
 	                                $output.= '">';
 										$output.= $online_link;
 	                                $output.= '</a>
@@ -295,20 +350,20 @@ class Tribe__Extension__Virtual__Event__Ticket extends Tribe__Extension {
 		}
 
 		$online_link = get_post_meta( $event_id, $this->get_event_online_field(), true );
-		if ( !empty( $online_link ) ) {
-			$heading = tribe_get_option( 'eventsOnlineHeading' );
+		$heading = tribe_get_option( 'eventsOnlineHeading' );
+		if ( !empty( $online_link ) && !is_array( $online_link1 ) ) {
 			echo $this->get_email_link_template($online_link,$heading);
 		}
 
-		$online_link2 = tribe_get_option( 'eventsOnlineField2' );
-		if ( !empty( $online_link2 ) ) {
-			$heading2 = tribe_get_option( 'eventsOnlineHeading2' );
+		$online_link2 = get_post_meta( $event_id, $this->get_event_online_field2(), true );
+		$heading2 = tribe_get_option( 'eventsOnlineHeading2' );
+		if ( !empty( $online_link2 ) && !is_array( $online_link2 ) ) {
 			echo $this->get_email_link_template($online_link2,$heading2);
 		}
 
-		$online_link3 = tribe_get_option( 'eventsOnlineField3' );
-		if ( !empty( $online_link3 ) ) {
-			$heading3 = tribe_get_option( 'eventsOnlineHeading3' );
+		$online_link3 = get_post_meta( $event_id, $this->get_event_online_field3(), true );
+		$heading3 = tribe_get_option( 'eventsOnlineHeading3' );
+		if ( !empty( $online_link3 ) && !is_array( $online_link3 ) ) {
 			echo $this->get_email_link_template($online_link3,$heading3);
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Plugin URI: https://theeventscalendar.com/extensions/add-a-private-event-link-to
 GitHub Plugin URI: https://github.com/mt-support/tribe-ext-online-event
 Tags: events, calendar
 Requires at least: 4.7
-Tested up to: 5.4
+Tested up to: 5.4.2
 Requires PHP: 5.6
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPL version 2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -37,6 +37,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [premium forums](https://theeventscalendar.com/support-forums/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= v[1.2] July 16, 2020 =
+
+* Added 2 more (optional) fields that can also be included for alternative streaming/online event locations.
 
 = v[1.1.1] April 23, 2020 =
 

--- a/src/admin-views/tribe-options-virtual.php
+++ b/src/admin-views/tribe-options-virtual.php
@@ -35,7 +35,7 @@ $onlineTab = [
 		],
 		'info-box-description'            => [
 			'type' => 'html',
-			'html' => '<p>' . __( '<p>Choose the category and fields for events that are Online or Virtual. </p>', 'tribe-ext-online-events' ) . '</p>',
+			'html' => '<p>' . __( '<p>Choose the category and field(s) for events that are Online or Virtual. </p>', 'tribe-ext-online-events' ) . '</p>',
 		],
 		'info-end'                        => [
 			'type' => 'html',
@@ -67,7 +67,25 @@ $onlineTab = [
 
 $onlineTab['fields']['eventsOnlineField'] = [
 	'type'         => 'text',
-	'label'        => __( 'Custom field that contains Event link', 'tribe-ext-online-events' ),
+	'label'        => __( '<strong>Event Link #1</strong> Custom Field', 'tribe-ext-online-events' ),
+	'default'      => '',
+	'tooltip'      => __( 'To know more about Custom fields visit the WordPress <a target="_blank" href="https://wordpress.org/support/article/custom-fields/">Custom Fields Wiki</a>', 'tribe-ext-online-events' ),
+	'can_be_empty' => true,
+	'validation_type' => 'alpha_numeric_with_dashes_and_underscores',
+	'size'            => 'medium',
+];
+$onlineTab['fields']['eventsOnlineField2'] = [
+	'type'         => 'text',
+	'label'        => __( '<strong>Event Link #2</strong> Custom Field (optional)', 'tribe-ext-online-events' ),
+	'default'      => '',
+	'tooltip'      => __( 'To know more about Custom fields visit the WordPress <a target="_blank" href="https://wordpress.org/support/article/custom-fields/">Custom Fields Wiki</a>', 'tribe-ext-online-events' ),
+	'can_be_empty' => true,
+	'validation_type' => 'alpha_numeric_with_dashes_and_underscores',
+	'size'            => 'medium',
+];
+$onlineTab['fields']['eventsOnlineField3'] = [
+	'type'         => 'text',
+	'label'        => __( '<strong>Event link #3</strong> Custom Field (optional)', 'tribe-ext-online-events' ),
 	'default'      => '',
 	'tooltip'      => __( 'To know more about Custom fields visit the WordPress <a target="_blank" href="https://wordpress.org/support/article/custom-fields/">Custom Fields Wiki</a>', 'tribe-ext-online-events' ),
 	'can_be_empty' => true,
@@ -82,9 +100,30 @@ $onlineTab['fields']['eventsOnlineFieldHelperEmail'] = [
 
 $onlineTab['fields']['eventsOnlineHeading'] = [
 	'type'            => 'text',
-	'label'           => __( 'Email Heading for link', 'tribe-ext-online-events' ),
+	'label'           => __( '<strong>Event Link #1</strong> Email Heading', 'tribe-ext-online-events' ),
 	'tooltip'         => '',
 	'default'         => 'Event Link',
+	'placeholder'     => 'Link #1 Label',
+	'validation_type' => 'html',
+	'size'            => 'medium',
+	'can_be_empty'    => false,
+];
+$onlineTab['fields']['eventsOnlineHeading2'] = [
+	'type'            => 'text',
+	'label'           => __( '<strong>Event Link #2</strong> Email Heading (optional)', 'tribe-ext-online-events' ),
+	'tooltip'         => '',
+	'default'         => 'Event Link #2',
+	'placeholder'     => 'Link #2 Label',
+	'validation_type' => 'html',
+	'size'            => 'medium',
+	'can_be_empty'    => false,
+];
+$onlineTab['fields']['eventsOnlineHeading3'] = [
+	'type'            => 'text',
+	'label'           => __( '<strong>Event Link #3</strong> Email Heading (optional)', 'tribe-ext-online-events' ),
+	'tooltip'         => '',
+	'default'         => 'Event Link #3',
+	'placeholder'     => 'Link #3 Label',
 	'validation_type' => 'html',
 	'size'            => 'medium',
 	'can_be_empty'    => false,


### PR DESCRIPTION
I had a need where someone had an event on Facebook, YouTube, and possibly other locations. They then wanted each option listed so the attendees could choose based on whatever their preference is.

As is, this only allowed for one URL. This update adds 2 more URLs (with headers) that are then optional & are only included when needed.

You can see a screenshot of the updated admin page here: 
<img width="1004" alt="Screen Shot 2020-07-16 at 5 47 14 PM" src="https://user-images.githubusercontent.com/118200/87731087-3912b700-c78f-11ea-8c02-72c7eb5f70ee.png">

I then aimed to leave everything else as-is as much as I could.

I didn't want to overhaul it enough to have repeater field & array handling so I figured 3 is typically enough for those that might want/need it while not making the settings page cluttered.